### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,5 @@
         "test": "nodeunit tests/test.js"
     },
     "keywords": ["xpath", "xml"],
-    "licenses": [{ 
-        "type" :  "MIT License",
-        "url" :   "http://www.opensource.org/licenses/mit-license.php" }]
+    "license": "MIT
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/